### PR TITLE
Implement multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # esp8266 base image, repo here: https://github.com/resin-io-library/dependent-base-images/tree/master/esp8266
 # See more about resin base images here: http://docs.resin.io/runtime/resin-base-images/
-FROM resin/esp8266
+FROM resin/esp8266 AS buildstep
 
 # Set the working directory
 WORKDIR /usr/src/app
@@ -20,3 +20,9 @@ COPY lib/ ./lib
 # Compile the firmware
 RUN platformio run --environment $BOARD && \
     mv .pioenvs/$BOARD/firmware.bin /assets/
+
+# Start with a minimal runtime container
+FROM alpine
+
+# Copy the compiled firmware into the empty runtime container
+COPY --from=buildstep /assets/ /assets/


### PR DESCRIPTION
Implement multi-stage builds, reducing the final container size down to less than 4MB